### PR TITLE
important fix for wrong curl import statement for crossplatform compilation

### DIFF
--- a/contrib/cmake/FindCURL.cmake
+++ b/contrib/cmake/FindCURL.cmake
@@ -51,7 +51,7 @@ if(CURL_INCLUDE_DIR)
 endif()
 # handle the QUIETLY and REQUIRED arguments and set CURL_FOUND to TRUE if
 # all listed variables are TRUE
-include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(CURL
                                   REQUIRED_VARS CURL_LIBRARY CURL_INCLUDE_DIR
                                   VERSION_VAR CURL_VERSION_STRING)


### PR DESCRIPTION
The original FindCURL.cmake was made for MSVC environment. Unfortunately it has a defect on other platforms.

This quickfix solves the problem.