### PR TITLE
Added static build option for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ option(START_WITH_UPNP "If UPNP is enabled, turn it on at startup" OFF)
 option(ENABLE_GPROF "Use gprof profiling compiler flags " OFF)
 option(ENABLE_LEASING_MANAGER "Enable leasing manager" ON)
 option(ENABLE_TESTS "Build tests" ON)
+option(BUILD_STATIC "Build dependencies as static libs" OFF)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	set(DEFAULT_ENABLE_DBUS_NOTIFICATIONS ON)
@@ -217,6 +218,11 @@ if(ENABLE_TESTS)
 else()
     message(STATUS "Disabled option: Build tests")
 endif()
+if(BUILD_STATIC)
+    message(STATUS "Enabled option: Build static dependencies")
+else()
+    message(STATUS "Disabled option: Build static dependencies")
+endif()
 
 # If ccache is available, then use it.
 find_program(CCACHE ccache)
@@ -228,6 +234,14 @@ endif(CCACHE)
 
 # flags
 include(AddCompilerFlags)
+
+if(BUILD_STATIC)
+    add_linker_flags(-static)
+endif()
+
+if(BUILD_STATIC AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a"  CACHE STRING "CMake search suffix" FORCE)
+endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	# Ensure that WINDRES_PREPROC is enabled when using windres.
@@ -399,6 +413,9 @@ if (MSVC)
     # warning LNK4099: pdb was not found with lib
     # stack size 16MB
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099,4075 /STACK:16777216 /NODEFAULTLIB:MSVCRT -DWINVER=0x0A00 -D_WIN32_WINNT=0x0A00")
+elseif(BUILD_STATIC)
+    set(BUILD_SHARED_LIBS OFF)
+    set(BUILD_STATIC_LIBS ON)
 else()
     set(BUILD_SHARED_LIBS ON)
     set(BUILD_STATIC_LIBS ON)
@@ -461,8 +478,13 @@ else()
     set( BOOST_ROOT "usr" )
     set( Boost_INCLUDE_DIR "/usr/include" )
     set( Boost_NO_BOOST_CMAKE ON )
-    set( Boost_USE_STATIC_LIBS  OFF )
-    set( Boost_USE_STATIC_RUNTIME OFF )
+    if(BUILD_STATIC)
+        set( Boost_USE_STATIC_LIBS ON )
+        set( Boost_USE_STATIC_RUNTIME ON )
+    else()
+        set( Boost_USE_STATIC_LIBS  OFF )
+        set( Boost_USE_STATIC_RUNTIME OFF )
+    endif()
 endif()
 
 set( Boost_USE_MULTITHREADED ON )
@@ -487,6 +509,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
         BOOST_LOG_BUILDING_THE_LIB=1
         BOOST_THREAD_USE_LIB=1
 	)
+elseif(BUILD_STATIC)
+    add_definitions(-DBOOST_ALL_STATIC_LINK=1)
+    add_definitions(-DBOOST_LOG_STATIC_LINK=1)
 else()
     add_definitions(-DBOOST_LOG_DYN_LINK=1)
     add_definitions(-DBOOST_ALL_DYN_LINK=1)
@@ -526,7 +551,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	list(APPEND CMAKE_PREFIX_PATH /usr/local/opt/snappy)
 	list(APPEND CMAKE_PREFIX_PATH /usr/local/opt/libevent)
     
-	set(BerkeleyDB_ROOT_DIR "/usr/local/opt/berkeley-db")
+	set( BerkeleyDB_ROOT_DIR "/usr/local/opt/berkeley-db")
 
 	set( CURL_INCLUDE_DIR "/usr/local/opt/curl/include" )
 	set( CURL_LIBRARY "/usr/local/opt/curl/lib" )
@@ -748,9 +773,6 @@ if(ZeroMQ_FOUND)
     
     message(STATUS ZeroMQ_LIBRARY:)
     message (STATUS ${ZeroMQ_LIBRARY})
-    
-    message(STATUS ZeroMQ_STATIC_LIBRARY:)
-    message (STATUS ${ZeroMQ_STATIC_LIBRARY})
 else()
     message(WARNING "ZeroMQ not found!")
 endif()
@@ -1196,19 +1218,19 @@ target_link_libraries(SERVER_A
         Threads::Threads
         scrypt
         )
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
     target_link_libraries(SERVER_A 
         ${ZeroMQ_STATIC_LIBRARY} jsoncpp_lib_static cryptopp-static Oracle::BerkeleyDB
         )
-    if(CRYPT32_LIBRARY)
-        target_link_libraries(SERVER_A 
-            ${CRYPT32_LIBRARY}
-        )
-    endif()
 else()
     target_link_libraries(SERVER_A 
         ${ZeroMQ_LIBRARY} jsoncpp_lib cryptopp-shared ${BerkeleyDB_Cxx_LIBRARY}
         )
+endif()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" AND CRYPT32_LIBRARY)
+    target_link_libraries(SERVER_A 
+        ${CRYPT32_LIBRARY}
+    )
 endif()
 
 
@@ -1260,7 +1282,7 @@ if(ZeroMQ_FOUND)
         ${OPENSSL_INCLUDE_DIR}
         ${Boost_INCLUDE_DIRS}
         )
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
         target_link_libraries(ZMQ_A 
             ${ZeroMQ_STATIC_LIBRARY}
             )
@@ -1389,7 +1411,7 @@ target_link_libraries(COMMON_A
             UTIL_A
             SERVER_A
         )
-if (MSVC)
+if (MSVC OR BUILD_STATIC)
     target_link_libraries(COMMON_A jsoncpp_lib_static)
 else()
     target_link_libraries(COMMON_A jsoncpp_lib)
@@ -1424,7 +1446,7 @@ target_link_libraries(ZEROCOIN_A
             COMMON_A
             secp256k1
         )
-if (MSVC)
+if (MSVC OR BUILD_STATIC)
     target_link_libraries(ZEROCOIN_A jsoncpp_lib_static cryptopp-static)
 else()
     target_link_libraries(ZEROCOIN_A jsoncpp_lib cryptopp-shared)
@@ -1581,7 +1603,7 @@ if(GMP_FOUND)
 endif()
 if(ZeroMQ_FOUND)
     target_link_libraries(btcud ZMQ_A)
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
         target_link_libraries(btcud 
             ${ZeroMQ_STATIC_LIBRARY}
             )
@@ -1593,7 +1615,7 @@ if(ZeroMQ_FOUND)
     target_include_directories(btcud PUBLIC ${ZeroMQ_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp-ethereum/)
 endif()
 if(MINIUPNP_FOUND)
-	if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+	if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
 		target_compile_definitions(btcud
 			PUBLIC -DSTATICLIB
 			PUBLIC -DMINIUPNP_STATICLIB
@@ -1764,7 +1786,7 @@ if(ENABLE_TESTS)
     if(ZeroMQ_FOUND)
         target_link_libraries(test_btcu ZMQ_A)
         target_include_directories(test_btcu PUBLIC ${ZeroMQ_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp-ethereum/)
-        if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
             target_link_libraries(test_btcu 
                 ${ZeroMQ_STATIC_LIBRARY}
                 )
@@ -1775,7 +1797,7 @@ if(ENABLE_TESTS)
         endif()
     endif()
     if(MINIUPNP_FOUND)
-        if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
             target_compile_definitions(test_btcu
                 PUBLIC -DSTATICLIB
                 PUBLIC -DMINIUPNP_STATICLIB

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -22,7 +22,7 @@ set(COPYRIGHT_YEAR 2021)
 
 option(CLIENT_VERSION_IS_RELEASE "Build a release version" OFF)
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
     # turning off static libs for correct config tests
     set(BUILD_STATIC_LIBS OFF)
 endif()
@@ -633,7 +633,7 @@ if(_HAVE_STD_SYSTEM OR _HAVE_WSYSTEM)
 	set(HAVE_SYSTEM 1)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
     set(BUILD_STATIC_LIBS ON)
 endif()
 

--- a/src/cpp-ethereum/CMakeLists.txt
+++ b/src/cpp-ethereum/CMakeLists.txt
@@ -40,7 +40,7 @@ include(EthExecutableHelper)
 include(EthDependencies)
 include(EthUtils)
 
-if (MSVC)
+if (MSVC OR BUILD_STATIC)
     set(BUILD_SHARED_LIBS OFF)
     set(BUILD_STATIC_LIBS ON)
 endif()

--- a/src/cpp-ethereum/libdevcrypto/CMakeLists.txt
+++ b/src/cpp-ethereum/libdevcrypto/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(devcrypto
         cryptopp-shared 
         ${LIBCRYPT_LIBRARY}
         )
-if (MSVC)
+if (MSVC OR BUILD_STATIC)
     target_link_libraries(devcrypto cryptopp-static)
 else()
     target_link_libraries(devcrypto cryptopp-shared)

--- a/src/cryptopp/CMakeLists.txt
+++ b/src/cryptopp/CMakeLists.txt
@@ -110,7 +110,6 @@ else()
 		option(BUILD_TESTING "Build library tests" ON)
 	endif()
 
-	option(BUILD_STATIC "Build static library" ON)
 	option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
 
 	option(DISABLE_ASM "Disable ASM" OFF)

--- a/src/jsoncpp/jsoncpp/src/jsontestrunner/CMakeLists.txt
+++ b/src/jsoncpp/jsoncpp/src/jsontestrunner/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(jsontestrunner_exe
     main.cpp
 )
 
-if(BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS AND NOT BUILD_STATIC)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
         add_compile_definitions( JSON_DLL )
     else()

--- a/src/jsoncpp/jsoncpp/src/test_lib_json/CMakeLists.txt
+++ b/src/jsoncpp/jsoncpp/src/test_lib_json/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(jsoncpp_test
 )
 
 
-if(BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS AND NOT BUILD_STATIC)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
         add_compile_definitions( JSON_DLL )
     else()

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -19,7 +19,7 @@ endif ()
 find_package(Qrcode REQUIRED)
 include_directories ( ${Qrcode_INCLUDE_DIRS} )
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
 	set(Qt5_USE_STATIC_LIBS ON)
 	set(Qt5_USE_STATIC_RUNTIME ON)
 endif ()
@@ -311,7 +311,7 @@ if(GMP_FOUND)
 endif()
 if(ZeroMQ_FOUND)
     target_link_libraries(btcu-qt ZMQ_A)
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
 		target_link_libraries(btcu-qt 
 			${ZeroMQ_STATIC_LIBRARY}
 			)
@@ -327,7 +327,7 @@ if (Qrcode_FOUND)
     target_include_directories(btcu-qt PUBLIC ${Qrcode_INCLUDE_DIRS})
 endif()
 if(MINIUPNP_FOUND)
-	if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+	if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
 		target_compile_definitions(btcu-qt
 			PUBLIC -DSTATICLIB
 			PUBLIC -DMINIUPNP_STATICLIB
@@ -655,7 +655,7 @@ if(ENABLE_TESTS)
 	endif()
 	if(ZeroMQ_FOUND)
 		target_link_libraries(test_btcu-qt PUBLIC ZMQ_A)
-		if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+		if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
 			target_link_libraries(test_btcu-qt PUBLIC
 				${ZeroMQ_STATIC_LIBRARY}
 				)
@@ -667,7 +667,7 @@ if(ENABLE_TESTS)
 		target_include_directories(test_btcu-qt PUBLIC ${ZeroMQ_INCLUDE_DIRS})
 	endif()
 	if(MINIUPNP_FOUND)
-		if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+		if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" OR BUILD_STATIC)
 			target_compile_definitions(test_btcu-qt
 				PUBLIC -DSTATICLIB
 				PUBLIC -DMINIUPNP_STATICLIB

--- a/src/secp256k1/CMakeLists.txt
+++ b/src/secp256k1/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_C_STANDARD 90)
 include(TestBigEndian)
 include(CheckCSourceCompiles)
 
-if (MSVC)
+if (MSVC OR BUILD_STATIC)
     set(BUILD_SHARED_LIBS OFF)
     set(BUILD_STATIC_LIBS ON)
 else()

--- a/src/univalue/CMakeLists.txt
+++ b/src/univalue/CMakeLists.txt
@@ -7,7 +7,7 @@ project(univalue
 
 option(UNIVALUE_BUILD_TESTS "Build univalue's unit tests" ON)
 
-if (MSVC)
+if (MSVC OR BUILD_STATIC)
     set(BUILD_SHARED_LIBS OFF)
     set(BUILD_STATIC_LIBS ON)
 else()


### PR DESCRIPTION
The feature contains a new options for the CMake: BUILD_STATIC. 
With the followed command:
`cmake . -DBUILD_STATIC=ON`
it is possible to build a binary with static dependencies.